### PR TITLE
added the postgresql fix for #7446

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -386,7 +386,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				$result[$field->column_name] = preg_replace("/[(0-9)]/", '', $field->type);
+				$result[$field->column_name] = preg_replace("/[(0-9)],?/", '', $field->type);
 			}
 		}
 		else


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/7446 added the fix for the postgresql driver

i've tested with this table  cause (float(3,4) not allowed on postgresql)
```
CREATE TABLE #__compound_types (
    "id" serial NOT NULL,
    "single_float" FLOAT,
    "compound_float" FLOAT(8),
    "string" VARCHAR(255),
    "single_decimal" DECIMAL,
    "compound_decimal" DECIMAL(10, 2),
  PRIMARY KEY ("id"),
  CONSTRAINT "#__TEST_idx_string" UNIQUE ("string")
);
```