### PR TITLE
Unit test loading behavior, don't explicitly import JFactory now

### DIFF
--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -59,9 +59,6 @@ JLoader::setup();
 
 JLoader::registerPrefix('J', JPATH_PLATFORM . '/legacy');
 
-// Import the Joomla Factory.
-JLoader::import('joomla.factory');
-
 // Register classes that don't follow one file per class naming conventions.
 JLoader::register('JText', JPATH_PLATFORM . '/joomla/language/text.php');
 JLoader::register('JRoute', JPATH_PLATFORM . '/joomla/application/route.php');

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -49,9 +49,6 @@ if (!class_exists('JLoader'))
 // Setup the autoloaders.
 JLoader::setup();
 
-// Import the base Joomla Platform libraries.
-JLoader::import('joomla.factory');
-
 // Check if the JsonSerializable interface exists already
 if (!interface_exists('JsonSerializable'))
 {

--- a/tests/unit/stubs/loader/patch.php
+++ b/tests/unit/stubs/loader/patch.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package    Joomla.Platform
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+class JoomlaPatch
+{
+}

--- a/tests/unit/stubs/loader/patch/tester.php
+++ b/tests/unit/stubs/loader/patch/tester.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package    Joomla.Platform
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+class JoomlaPatchTester
+{
+}

--- a/tests/unit/stubs/loader/tester/tester.php
+++ b/tests/unit/stubs/loader/tester/tester.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package    Joomla.Platform
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+class JoomlaTester
+{
+}

--- a/tests/unit/suites/libraries/joomla/JLoaderTest.php
+++ b/tests/unit/suites/libraries/joomla/JLoaderTest.php
@@ -220,6 +220,23 @@ class JLoaderTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the JLoader::load method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLoadForSinglePart()
+	{
+		JLoader::registerPrefix('Joomla', JPATH_TEST_STUBS . '/loader', true);
+
+		$this->assertTrue(class_exists('JoomlaPatch'), 'Tests that a class with a single part is loaded in the base path.');
+		$this->assertTrue(class_exists('JoomlaPatchTester'), 'Tests that a class with multiple parts is loaded from the correct path.');
+		$this->assertTrue(class_exists('JoomlaTester'), 'Tests that a class with a single part is loaded from a folder (legacy behavior).');
+		$this->assertFalse(class_exists('JoomlaNotPresent'), 'Tests that a non-existing class is not found.');
+	}
+
+	/**
 	 * Tests if JLoader::applyAliasFor runs automatically when loading a class by its real name
 	 *
 	 * @return  void


### PR DESCRIPTION
Adds unit test coverage validating the changed behavior and removes the explicit import of JFactory as the autoloader can now load it.